### PR TITLE
Use original text if translation is empty

### DIFF
--- a/src/GuJian3Library/Converters/ExeSection/Reader.cs
+++ b/src/GuJian3Library/Converters/ExeSection/Reader.cs
@@ -138,7 +138,7 @@ namespace GuJian3Library.Converters.ExeSection
 
                             _strings[path] = value;
 
-                            if (_newStrings.ContainsKey(path))
+                            if (_newStrings.ContainsKey(path) && !string.IsNullOrEmpty(_newStrings[path]))
                             {
                                 value = _newStrings[path];
                             }
@@ -161,7 +161,7 @@ namespace GuJian3Library.Converters.ExeSection
 
                             _strings[path] = value;
 
-                            if (_newStrings.ContainsKey(path))
+                            if (_newStrings.ContainsKey(path) && !string.IsNullOrEmpty(_newStrings[path]))
                             {
                                 value = _newStrings[path];
                             }


### PR DESCRIPTION
### Description

User the original string if translation in PO is empty.