### PR TITLE
Unescape the slash when reading po files.

### DIFF
--- a/src/GuJian3Tool/Program.BuildText.cs
+++ b/src/GuJian3Tool/Program.BuildText.cs
@@ -72,7 +72,7 @@ namespace GuJian3Tool
 
                 foreach (PoEntry poEntry in po.Entries)
                 {
-                    newStrings.Add(poEntry.Context, poEntry.Translated);
+                    newStrings.Add(poEntry.Context, poEntry.Translated.Replace("\\\\", "\\"));
                 }
             }
 


### PR DESCRIPTION
### Description

The `\` character was escaped when creating the po files, but was not unescaped on reading.